### PR TITLE
Bug fixes for `test` and `build` steps

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -47,7 +47,6 @@ jobs:
       call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
       call "C:\opt\ros\melodic\x64\env.bat" catkin_init_workspace
       call "C:\opt\ros\melodic\x64\env.bat" catkin_make_isolated --use-ninja --install --source src ^
-      --cmake-args ^
       -DPYTHON_VERSION=2.7 ^
       -DPYTHON_EXECUTABLE=C:\opt\python27amd64\python.exe ^
       -DPYTHON_LIBRARIES=C:\opt\python27amd64\Libs ^

--- a/build.yml
+++ b/build.yml
@@ -62,7 +62,7 @@ jobs:
       set PATH=%PATH:C:\Program Files\Git\mingw64\bin;=%
       set PATH=%PATH:C:\ProgramData\chocolatey\bin;=%
       set PATH=%PATH:C:\Strawberry\c\bin;=%
-      call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+      call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
       call "C:\opt\ros\melodic\x64\setup.bat"
       call "devel_isolated\setup.bat"
       catkin_make_isolated --use-ninja --install --source src --catkin-make-args %CUSTOM_TEST_TARGET% ^

--- a/build.yml
+++ b/build.yml
@@ -47,6 +47,7 @@ jobs:
       call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
       call "C:\opt\ros\melodic\x64\env.bat" catkin_init_workspace
       call "C:\opt\ros\melodic\x64\env.bat" catkin_make_isolated --use-ninja --install --source src ^
+      --cmake-args ^
       -DPYTHON_VERSION=2.7 ^
       -DPYTHON_EXECUTABLE=C:\opt\python27amd64\python.exe ^
       -DPYTHON_LIBRARIES=C:\opt\python27amd64\Libs ^

--- a/tests/azure-pipelines.yml
+++ b/tests/azure-pipelines.yml
@@ -2,7 +2,7 @@ resources:
   repositories:
     - repository: templates
       type: github
-      name: seanyen/rosonwindows_ci
+      name: ms-iot/rosonwindows_ci
       endpoint: ms-iot
 
 jobs:

--- a/tests/azure-pipelines.yml
+++ b/tests/azure-pipelines.yml
@@ -2,7 +2,7 @@ resources:
   repositories:
     - repository: templates
       type: github
-      name: ms-iot/rosonwindows_ci
+      name: seanyen/rosonwindows_ci
       endpoint: ms-iot
 
 jobs:

--- a/tests/azure-pipelines.yml
+++ b/tests/azure-pipelines.yml
@@ -5,6 +5,11 @@ resources:
       name: ms-iot/rosonwindows_ci
       endpoint: ms-iot
 
+pr:
+  branches:
+    include:
+      - master
+
 jobs:
 - template: build.yml@templates  # Template reference
   parameters:


### PR DESCRIPTION
* Activated the same & matched VS2019 developer environment for both build and test. Otherwise, it will render as a warning. 
* Added `--cmake-args` for build step to correctly pass the CMAKE arguments.