### PR TITLE
Adding initial Linux support

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -1,5 +1,5 @@
 parameters:
-- name: ros_metapackage
+- name: ros_metapackage # Deprecated
   type: string
   default: 'ros-melodic-desktop'
 - name: rosdistro

--- a/build.yml
+++ b/build.yml
@@ -135,4 +135,13 @@ jobs:
     container: osrf/ros:melodic-desktop
     timeoutInMinutes: 240
     steps:
-    - script: printenv
+    - checkout: self
+      submodules: recursive
+    - task: CopyFiles@2
+      inputs:
+        targetFolder: '$(Build.StagingDirectory)\src\_'
+    - script: |
+        source /opt/ros/melodic/setup.sh
+        catkin_make_isolated --install --source src
+      displayName: Build repository
+      workingDirectory: '$(Build.StagingDirectory)'

--- a/build.yml
+++ b/build.yml
@@ -2,6 +2,12 @@ parameters:
 - name: ros_metapackage
   type: string
   default: 'ros-melodic-desktop'
+- name: rosdistro
+  type: string
+  default: 'melodic'
+- name: metapackage
+  type: string
+  default: 'desktop'
 - name: custom_test_target
   type: string
   default: 'run_tests'
@@ -25,6 +31,9 @@ jobs:
     pool:
       vmImage: 'windows-2019'
     timeoutInMinutes: 240
+    variables:
+      CI_ROSDISTRO: '${{ parameters.rosdistro }}'
+      CI_METAPACKAGE: '${{ parameters.metapackage }}'
     steps:
     - checkout: self
       submodules: recursive
@@ -35,7 +44,7 @@ jobs:
     - ${{ parameters.pre_build }}
     - script: |
         choco sources add -n=roswin -s https://roswin.azurewebsites.net/api/v2/ --priority 1
-        choco upgrade %ROS_METAPACKAGE% -y
+        choco upgrade ros-%CI_ROSDISTRO%-%CI_METAPACKAGE% -y
         call "C:\opt\ros\melodic\x64\env.bat" rosdep install --from-paths src --ignore-src -r -y
       env:
         ROS_METAPACKAGE: ${{ parameters.ros_metapackage }}
@@ -132,8 +141,11 @@ jobs:
   - job: Linux_Build
     pool:
       vmImage: 'ubuntu-18.04'
-    container: osrf/ros:melodic-desktop
+    container: 'osrf/ros:${{ parameters.rosdistro }}-${{ parameters.metapackage }}'
     timeoutInMinutes: 240
+    variables:
+      CI_ROSDISTRO: '${{ parameters.rosdistro }}'
+      CI_METAPACKAGE: '${{ parameters.metapackage }}'
     steps:
     - checkout: self
       submodules: recursive
@@ -143,12 +155,13 @@ jobs:
         targetFolder: '$(Build.StagingDirectory)/src/_'
 
     - script: |
-        source /opt/ros/melodic/setup.sh
+        source /opt/ros/$CI_ROSDISTRO/setup.sh
         catkin_make_isolated --install --source src
       displayName: Build repository
       workingDirectory: '$(Build.StagingDirectory)'
 
     - script: |
+        source /opt/ros/$CI_ROSDISTRO/setup.sh
         catkin_make_isolated --use-ninja --install --source src --catkin-make-args $CUSTOM_TEST_TARGET
       env:
         CUSTOM_TEST_TARGET: ${{ parameters.custom_test_target }}

--- a/build.yml
+++ b/build.yml
@@ -23,7 +23,6 @@ parameters:
 - name: platforms
   type: object
   default:
-    - linux
     - windows
 
 jobs:

--- a/build.yml
+++ b/build.yml
@@ -137,11 +137,46 @@ jobs:
     steps:
     - checkout: self
       submodules: recursive
+
     - task: CopyFiles@2
       inputs:
         targetFolder: '$(Build.StagingDirectory)/src/_'
+
     - script: |
         source /opt/ros/melodic/setup.sh
         catkin_make_isolated --install --source src
       displayName: Build repository
       workingDirectory: '$(Build.StagingDirectory)'
+
+    - script: |
+        catkin_make_isolated --use-ninja --install --source src --catkin-make-args $CUSTOM_TEST_TARGET
+      env:
+        CUSTOM_TEST_TARGET: ${{ parameters.custom_test_target }}
+      displayName: Test repository
+      timeoutInMinutes: ${{ parameters.custom_test_timeout }}
+      continueOnError: 'true'
+      workingDirectory: '$(Build.StagingDirectory)'
+
+    - task: PublishTestResults@2
+      displayName: Publish nosetests results
+      inputs:
+        testRunner: 'jUnit'
+        testResultsFiles: '**/nosetests-*.xml'
+        searchFolder: '$(Build.StagingDirectory)/build_isolated'
+      condition: always()
+
+    - task: PublishTestResults@2
+      displayName: Publish rostest results
+      inputs:
+        testRunner: 'jUnit'
+        testResultsFiles: '**/rostest-*.xml'
+        searchFolder: '$(Build.StagingDirectory)/build_isolated'
+      condition: always()
+
+    - task: PublishTestResults@2
+      displayName: Publish gtest results
+      inputs:
+        testRunner: 'jUnit'
+        testResultsFiles: '**/gtest-*.xml'
+        searchFolder: '$(Build.StagingDirectory)/build_isolated'
+      condition: always()

--- a/build.yml
+++ b/build.yml
@@ -14,12 +14,17 @@ parameters:
 - name: build_chocolatey_pkg
   type: boolean
   default: false
+- name: platforms
+  type: object
+  default:
+    - windows
 
 jobs:
-- job: Build
+- job: Windows Build
   pool:
     vmImage: 'windows-2019'
   timeoutInMinutes: 240
+  condition: containsValue(${{ parameters.platforms }}, 'windows')
   steps:
   - checkout: self
     submodules: recursive
@@ -101,14 +106,14 @@ jobs:
       testResultsFiles: '**\gtest-*.xml'
       searchFolder: '$(Build.StagingDirectory)\build_isolated'
     condition: always()
-    
+
   - task: ArchiveFiles@2
     inputs:
       rootFolderOrFile: '$(Build.StagingDirectory)\install_isolated'
       includeRootFolder: false
       archiveFile: '$(Build.Repository.LocalPath)\package\tools\drop.zip'
     displayName: 'Archive Package binaries'
-  
+
   - script: |
       call "$(Build.Repository.LocalPath)\package\build.bat"
     displayName: Build Chocolatey Package
@@ -116,7 +121,7 @@ jobs:
     continueOnError: 'true'
     workingDirectory: '$(Build.Repository.LocalPath)\package'
     condition: and(succeeded(), eq('${{ parameters.build_chocolatey_pkg }}', true))
-    
+
   - task: PublishPipelineArtifact@1
     inputs:
       targetPath: $(Build.Repository.LocalPath)\package\output

--- a/build.yml
+++ b/build.yml
@@ -17,7 +17,7 @@ parameters:
 - name: platforms
   type: object
   default:
-    - windows
+    - linux
 
 jobs:
 - job: Windows Build
@@ -127,3 +127,12 @@ jobs:
       targetPath: $(Build.Repository.LocalPath)\package\output
       artifactName: choco_artifact
     condition: and(succeeded(), eq('${{ parameters.build_chocolatey_pkg }}', true))
+
+- job: Linux Build
+  pool:
+    vmImage: 'ubuntu-18.04'
+  container: osrf/ros:melodic-desktop
+  timeoutInMinutes: 240
+  condition: containsValue(${{ parameters.platforms }}, 'linux')
+  steps:
+  - script: printenv

--- a/build.yml
+++ b/build.yml
@@ -20,7 +20,7 @@ parameters:
     - linux
 
 jobs:
-- job: Windows Build
+- job: Windows_Build
   pool:
     vmImage: 'windows-2019'
   timeoutInMinutes: 240
@@ -128,7 +128,7 @@ jobs:
       artifactName: choco_artifact
     condition: and(succeeded(), eq('${{ parameters.build_chocolatey_pkg }}', true))
 
-- job: Linux Build
+- job: Linux_Build
   pool:
     vmImage: 'ubuntu-18.04'
   container: osrf/ros:melodic-desktop

--- a/build.yml
+++ b/build.yml
@@ -46,8 +46,6 @@ jobs:
         choco sources add -n=roswin -s https://roswin.azurewebsites.net/api/v2/ --priority 1
         choco upgrade ros-%CI_ROSDISTRO%-%CI_METAPACKAGE% -y
         call "C:\opt\ros\%CI_ROSDISTRO%\x64\env.bat" rosdep install --from-paths src --ignore-src -r -y
-      env:
-        ROS_METAPACKAGE: ${{ parameters.ros_metapackage }}
       displayName: Install prerequisites
       workingDirectory: $(Build.StagingDirectory)
 

--- a/build.yml
+++ b/build.yml
@@ -17,7 +17,7 @@ parameters:
 - name: pre_build
   type: stepList
   default: []
-- name: build_chocolatey_pkg
+- name: build_chocolatey_pkg # Only supported for Windows build.
   type: boolean
   default: false
 - name: platforms
@@ -153,6 +153,8 @@ jobs:
     - task: CopyFiles@2
       inputs:
         targetFolder: '$(Build.StagingDirectory)/src/_'
+
+    - ${{ parameters.pre_build }}
 
     - script: |
         source /opt/ros/$CI_ROSDISTRO/setup.sh

--- a/build.yml
+++ b/build.yml
@@ -24,7 +24,7 @@ jobs:
   pool:
     vmImage: 'windows-2019'
   timeoutInMinutes: 240
-  condition: contains(${{ parameters.platforms }}, 'windows')
+  condition: contains(variables.platforms, 'windows')
   steps:
   - checkout: self
     submodules: recursive
@@ -133,6 +133,6 @@ jobs:
     vmImage: 'ubuntu-18.04'
   container: osrf/ros:melodic-desktop
   timeoutInMinutes: 240
-  condition: contains(${{ parameters.platforms }}, 'linux')
+  condition: contains(variables.platforms, 'linux')
   steps:
   - script: printenv

--- a/build.yml
+++ b/build.yml
@@ -24,7 +24,7 @@ jobs:
   pool:
     vmImage: 'windows-2019'
   timeoutInMinutes: 240
-  condition: contains(variables.platforms, 'windows')
+  condition: containsValue(variables.platforms, 'windows')
   steps:
   - checkout: self
     submodules: recursive
@@ -133,6 +133,6 @@ jobs:
     vmImage: 'ubuntu-18.04'
   container: osrf/ros:melodic-desktop
   timeoutInMinutes: 240
-  condition: contains(variables.platforms, 'linux')
+  condition: containsValue(variables.platforms, 'linux')
   steps:
   - script: printenv

--- a/build.yml
+++ b/build.yml
@@ -45,7 +45,7 @@ jobs:
     - script: |
         choco sources add -n=roswin -s https://roswin.azurewebsites.net/api/v2/ --priority 1
         choco upgrade ros-%CI_ROSDISTRO%-%CI_METAPACKAGE% -y
-        call "C:\opt\ros\melodic\x64\env.bat" rosdep install --from-paths src --ignore-src -r -y
+        call "C:\opt\ros\%CI_ROSDISTRO%\x64\env.bat" rosdep install --from-paths src --ignore-src -r -y
       env:
         ROS_METAPACKAGE: ${{ parameters.ros_metapackage }}
       displayName: Install prerequisites
@@ -59,8 +59,8 @@ jobs:
         set PATH=%PATH:C:\ProgramData\chocolatey\bin;=%
         set PATH=%PATH:C:\Strawberry\c\bin;=%
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-        call "C:\opt\ros\melodic\x64\env.bat" catkin_init_workspace
-        call "C:\opt\ros\melodic\x64\env.bat" catkin_make_isolated --use-ninja --install --source src ^
+        call "C:\opt\ros\%CI_ROSDISTRO%\x64\env.bat" catkin_init_workspace
+        call "C:\opt\ros\%CI_ROSDISTRO%\x64\env.bat" catkin_make_isolated --use-ninja --install --source src ^
         --cmake-args ^
         -DPYTHON_VERSION=2.7 ^
         -DPYTHON_EXECUTABLE=C:\opt\python27amd64\python.exe ^
@@ -77,7 +77,7 @@ jobs:
         set PATH=%PATH:C:\ProgramData\chocolatey\bin;=%
         set PATH=%PATH:C:\Strawberry\c\bin;=%
         call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-        call "C:\opt\ros\melodic\x64\setup.bat"
+        call "C:\opt\ros\%CI_ROSDISTRO%\x64\setup.bat"
         call "devel_isolated\setup.bat"
         catkin_make_isolated --use-ninja --install --source src --catkin-make-args %CUSTOM_TEST_TARGET% ^
         --cmake-args ^
@@ -162,7 +162,7 @@ jobs:
 
     - script: |
         source /opt/ros/$CI_ROSDISTRO/setup.sh
-        catkin_make_isolated --use-ninja --install --source src --catkin-make-args $CUSTOM_TEST_TARGET
+        catkin_make_isolated --install --source src --catkin-make-args $CUSTOM_TEST_TARGET
       env:
         CUSTOM_TEST_TARGET: ${{ parameters.custom_test_target }}
       displayName: Test repository

--- a/build.yml
+++ b/build.yml
@@ -24,7 +24,7 @@ jobs:
   pool:
     vmImage: 'windows-2019'
   timeoutInMinutes: 240
-  condition: containsValue(${{ parameters.platforms }}, 'windows')
+  condition: contains(${{ parameters.platforms }}, 'windows')
   steps:
   - checkout: self
     submodules: recursive
@@ -133,6 +133,6 @@ jobs:
     vmImage: 'ubuntu-18.04'
   container: osrf/ros:melodic-desktop
   timeoutInMinutes: 240
-  condition: containsValue(${{ parameters.platforms }}, 'linux')
+  condition: contains(${{ parameters.platforms }}, 'linux')
   steps:
   - script: printenv

--- a/build.yml
+++ b/build.yml
@@ -134,6 +134,5 @@ jobs:
       vmImage: 'ubuntu-18.04'
     container: osrf/ros:melodic-desktop
     timeoutInMinutes: 240
-    condition: containsValue(variables.platforms, 'linux')
     steps:
     - script: printenv

--- a/build.yml
+++ b/build.yml
@@ -139,7 +139,7 @@ jobs:
       submodules: recursive
     - task: CopyFiles@2
       inputs:
-        targetFolder: '$(Build.StagingDirectory)\src\_'
+        targetFolder: '$(Build.StagingDirectory)/src/_'
     - script: |
         source /opt/ros/melodic/setup.sh
         catkin_make_isolated --install --source src

--- a/build.yml
+++ b/build.yml
@@ -20,119 +20,120 @@ parameters:
     - linux
 
 jobs:
-- job: Windows_Build
-  pool:
-    vmImage: 'windows-2019'
-  timeoutInMinutes: 240
-  condition: containsValue(variables.platforms, 'windows')
-  steps:
-  - checkout: self
-    submodules: recursive
-  - task: CopyFiles@2
-    inputs:
-      targetFolder: '$(Build.StagingDirectory)\src\_'
+- ${{ if containsValue(parameters.platforms, 'windows') }}:
+  - job: Windows_Build
+    pool:
+      vmImage: 'windows-2019'
+    timeoutInMinutes: 240
+    steps:
+    - checkout: self
+      submodules: recursive
+    - task: CopyFiles@2
+      inputs:
+        targetFolder: '$(Build.StagingDirectory)\src\_'
 
-  - ${{ parameters.pre_build }}
-  - script: |
-      choco sources add -n=roswin -s https://roswin.azurewebsites.net/api/v2/ --priority 1
-      choco upgrade %ROS_METAPACKAGE% -y
-      call "C:\opt\ros\melodic\x64\env.bat" rosdep install --from-paths src --ignore-src -r -y
-    env:
-      ROS_METAPACKAGE: ${{ parameters.ros_metapackage }}
-    displayName: Install prerequisites
-    workingDirectory: $(Build.StagingDirectory)
+    - ${{ parameters.pre_build }}
+    - script: |
+        choco sources add -n=roswin -s https://roswin.azurewebsites.net/api/v2/ --priority 1
+        choco upgrade %ROS_METAPACKAGE% -y
+        call "C:\opt\ros\melodic\x64\env.bat" rosdep install --from-paths src --ignore-src -r -y
+      env:
+        ROS_METAPACKAGE: ${{ parameters.ros_metapackage }}
+      displayName: Install prerequisites
+      workingDirectory: $(Build.StagingDirectory)
 
-  - script: |
-      set PATH=%PATH:C:\tools\mingw64\bin;=%
-      set PATH=%PATH:C:\Program Files\Git\bin;=%
-      set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
-      set PATH=%PATH:C:\Program Files\Git\mingw64\bin;=%
-      set PATH=%PATH:C:\ProgramData\chocolatey\bin;=%
-      set PATH=%PATH:C:\Strawberry\c\bin;=%
-      call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-      call "C:\opt\ros\melodic\x64\env.bat" catkin_init_workspace
-      call "C:\opt\ros\melodic\x64\env.bat" catkin_make_isolated --use-ninja --install --source src ^
-      --cmake-args ^
-      -DPYTHON_VERSION=2.7 ^
-      -DPYTHON_EXECUTABLE=C:\opt\python27amd64\python.exe ^
-      -DPYTHON_LIBRARIES=C:\opt\python27amd64\Libs ^
-      -DCMAKE_VERBOSE_MAKEFILE=ON
-    displayName: Build repository
-    workingDirectory: '$(Build.StagingDirectory)'
-    
-  - script: |
-      set PATH=%PATH:C:\tools\mingw64\bin;=%
-      set PATH=%PATH:C:\Program Files\Git\bin;=%
-      set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
-      set PATH=%PATH:C:\Program Files\Git\mingw64\bin;=%
-      set PATH=%PATH:C:\ProgramData\chocolatey\bin;=%
-      set PATH=%PATH:C:\Strawberry\c\bin;=%
-      call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-      call "C:\opt\ros\melodic\x64\setup.bat"
-      call "devel_isolated\setup.bat"
-      catkin_make_isolated --use-ninja --install --source src --catkin-make-args %CUSTOM_TEST_TARGET% ^
-      --cmake-args ^
-      -DPYTHON_VERSION=2.7 ^
-      -DPYTHON_EXECUTABLE=C:\opt\python27amd64\python.exe ^
-      -DPYTHON_LIBRARIES=C:\opt\python27amd64\Libs ^
-      -DCMAKE_VERBOSE_MAKEFILE=ON
-    env:
-      CUSTOM_TEST_TARGET: ${{ parameters.custom_test_target }}
-    displayName: Test repository
-    timeoutInMinutes: ${{ parameters.custom_test_timeout }}
-    continueOnError: 'true'
-    workingDirectory: '$(Build.StagingDirectory)'
+    - script: |
+        set PATH=%PATH:C:\tools\mingw64\bin;=%
+        set PATH=%PATH:C:\Program Files\Git\bin;=%
+        set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
+        set PATH=%PATH:C:\Program Files\Git\mingw64\bin;=%
+        set PATH=%PATH:C:\ProgramData\chocolatey\bin;=%
+        set PATH=%PATH:C:\Strawberry\c\bin;=%
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        call "C:\opt\ros\melodic\x64\env.bat" catkin_init_workspace
+        call "C:\opt\ros\melodic\x64\env.bat" catkin_make_isolated --use-ninja --install --source src ^
+        --cmake-args ^
+        -DPYTHON_VERSION=2.7 ^
+        -DPYTHON_EXECUTABLE=C:\opt\python27amd64\python.exe ^
+        -DPYTHON_LIBRARIES=C:\opt\python27amd64\Libs ^
+        -DCMAKE_VERBOSE_MAKEFILE=ON
+      displayName: Build repository
+      workingDirectory: '$(Build.StagingDirectory)'
+      
+    - script: |
+        set PATH=%PATH:C:\tools\mingw64\bin;=%
+        set PATH=%PATH:C:\Program Files\Git\bin;=%
+        set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
+        set PATH=%PATH:C:\Program Files\Git\mingw64\bin;=%
+        set PATH=%PATH:C:\ProgramData\chocolatey\bin;=%
+        set PATH=%PATH:C:\Strawberry\c\bin;=%
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        call "C:\opt\ros\melodic\x64\setup.bat"
+        call "devel_isolated\setup.bat"
+        catkin_make_isolated --use-ninja --install --source src --catkin-make-args %CUSTOM_TEST_TARGET% ^
+        --cmake-args ^
+        -DPYTHON_VERSION=2.7 ^
+        -DPYTHON_EXECUTABLE=C:\opt\python27amd64\python.exe ^
+        -DPYTHON_LIBRARIES=C:\opt\python27amd64\Libs ^
+        -DCMAKE_VERBOSE_MAKEFILE=ON
+      env:
+        CUSTOM_TEST_TARGET: ${{ parameters.custom_test_target }}
+      displayName: Test repository
+      timeoutInMinutes: ${{ parameters.custom_test_timeout }}
+      continueOnError: 'true'
+      workingDirectory: '$(Build.StagingDirectory)'
 
-  - task: PublishTestResults@2
-    displayName: Publish nosetests results
-    inputs:
-      testRunner: 'jUnit'
-      testResultsFiles: '**\nosetests-*.xml'
-      searchFolder: '$(Build.StagingDirectory)\build_isolated'
-    condition: always()
+    - task: PublishTestResults@2
+      displayName: Publish nosetests results
+      inputs:
+        testRunner: 'jUnit'
+        testResultsFiles: '**\nosetests-*.xml'
+        searchFolder: '$(Build.StagingDirectory)\build_isolated'
+      condition: always()
 
-  - task: PublishTestResults@2
-    displayName: Publish rostest results
-    inputs:
-      testRunner: 'jUnit'
-      testResultsFiles: '**\rostest-*.xml'
-      searchFolder: '$(Build.StagingDirectory)\build_isolated'
-    condition: always()
+    - task: PublishTestResults@2
+      displayName: Publish rostest results
+      inputs:
+        testRunner: 'jUnit'
+        testResultsFiles: '**\rostest-*.xml'
+        searchFolder: '$(Build.StagingDirectory)\build_isolated'
+      condition: always()
 
-  - task: PublishTestResults@2
-    displayName: Publish gtest results
-    inputs:
-      testRunner: 'jUnit'
-      testResultsFiles: '**\gtest-*.xml'
-      searchFolder: '$(Build.StagingDirectory)\build_isolated'
-    condition: always()
+    - task: PublishTestResults@2
+      displayName: Publish gtest results
+      inputs:
+        testRunner: 'jUnit'
+        testResultsFiles: '**\gtest-*.xml'
+        searchFolder: '$(Build.StagingDirectory)\build_isolated'
+      condition: always()
 
-  - task: ArchiveFiles@2
-    inputs:
-      rootFolderOrFile: '$(Build.StagingDirectory)\install_isolated'
-      includeRootFolder: false
-      archiveFile: '$(Build.Repository.LocalPath)\package\tools\drop.zip'
-    displayName: 'Archive Package binaries'
+    - task: ArchiveFiles@2
+      inputs:
+        rootFolderOrFile: '$(Build.StagingDirectory)\install_isolated'
+        includeRootFolder: false
+        archiveFile: '$(Build.Repository.LocalPath)\package\tools\drop.zip'
+      displayName: 'Archive Package binaries'
 
-  - script: |
-      call "$(Build.Repository.LocalPath)\package\build.bat"
-    displayName: Build Chocolatey Package
-    timeoutInMinutes: ${{ parameters.custom_test_timeout }}
-    continueOnError: 'true'
-    workingDirectory: '$(Build.Repository.LocalPath)\package'
-    condition: and(succeeded(), eq('${{ parameters.build_chocolatey_pkg }}', true))
+    - script: |
+        call "$(Build.Repository.LocalPath)\package\build.bat"
+      displayName: Build Chocolatey Package
+      timeoutInMinutes: ${{ parameters.custom_test_timeout }}
+      continueOnError: 'true'
+      workingDirectory: '$(Build.Repository.LocalPath)\package'
+      condition: and(succeeded(), eq('${{ parameters.build_chocolatey_pkg }}', true))
 
-  - task: PublishPipelineArtifact@1
-    inputs:
-      targetPath: $(Build.Repository.LocalPath)\package\output
-      artifactName: choco_artifact
-    condition: and(succeeded(), eq('${{ parameters.build_chocolatey_pkg }}', true))
+    - task: PublishPipelineArtifact@1
+      inputs:
+        targetPath: $(Build.Repository.LocalPath)\package\output
+        artifactName: choco_artifact
+      condition: and(succeeded(), eq('${{ parameters.build_chocolatey_pkg }}', true))
 
-- job: Linux_Build
-  pool:
-    vmImage: 'ubuntu-18.04'
-  container: osrf/ros:melodic-desktop
-  timeoutInMinutes: 240
-  condition: containsValue(variables.platforms, 'linux')
-  steps:
-  - script: printenv
+- ${{ if containsValue(parameters.platforms, 'linux') }}:
+  - job: Linux_Build
+    pool:
+      vmImage: 'ubuntu-18.04'
+    container: osrf/ros:melodic-desktop
+    timeoutInMinutes: 240
+    condition: containsValue(variables.platforms, 'linux')
+    steps:
+    - script: printenv

--- a/build.yml
+++ b/build.yml
@@ -24,6 +24,7 @@ parameters:
   type: object
   default:
     - linux
+    - windows
 
 jobs:
 - ${{ if containsValue(parameters.platforms, 'windows') }}:

--- a/tests/azure-pipelines.yml
+++ b/tests/azure-pipelines.yml
@@ -3,7 +3,8 @@ resources:
     - repository: templates
       type: github
       name: seanyen/rosonwindows_ci
-      ref: 'refs/heads/seanyen/linux'
+      #ref: 'refs/heads/seanyen/linux'
+      ref: 'v0.1.0'
       endpoint: ms-iot
 
 pr:

--- a/tests/azure-pipelines.yml
+++ b/tests/azure-pipelines.yml
@@ -4,7 +4,7 @@ resources:
       type: github
       name: seanyen/rosonwindows_ci
       #ref: 'refs/heads/seanyen/linux'
-      ref: 'refs/tags/v0.1.0'
+      #ref: 'refs/tags/v0.1.0'
       endpoint: ms-iot
 
 pr:
@@ -15,4 +15,5 @@ pr:
 jobs:
 - template: build.yml@templates  # Template reference
   parameters:
-    ros_metapackage: 'ros-melodic-ros_core'
+    rosdistro: 'melodic'
+    metapackage: 'desktop'

--- a/tests/azure-pipelines.yml
+++ b/tests/azure-pipelines.yml
@@ -3,7 +3,7 @@ resources:
     - repository: templates
       type: github
       name: seanyen/rosonwindows_ci
-      #ref: 'refs/heads/seanyen/linux'
+      ref: 'refs/heads/seanyen/linux'
       #ref: 'refs/tags/v0.1.0'
       endpoint: ms-iot
 

--- a/tests/azure-pipelines.yml
+++ b/tests/azure-pipelines.yml
@@ -2,9 +2,7 @@ resources:
   repositories:
     - repository: templates
       type: github
-      name: seanyen/rosonwindows_ci
-      ref: 'refs/heads/seanyen/linux'
-      #ref: 'refs/tags/v0.1.0'
+      name: ms-iot/rosonwindows_ci
       endpoint: ms-iot
 
 pr:
@@ -21,5 +19,8 @@ schedules:
 jobs:
 - template: build.yml@templates  # Template reference
   parameters:
-    rosdistro: 'melodic'
-    metapackage: 'desktop'
+    rosdistro: melodic
+    metapackage: desktop
+    platforms:
+      - linux
+      - windows

--- a/tests/azure-pipelines.yml
+++ b/tests/azure-pipelines.yml
@@ -10,7 +10,7 @@ schedules:
         - master
 
 jobs:
-- template: ../build.yml@self  # Template reference
+- template: /build.yml@self  # Template reference
   parameters:
     rosdistro: melodic
     metapackage: desktop

--- a/tests/azure-pipelines.yml
+++ b/tests/azure-pipelines.yml
@@ -1,10 +1,3 @@
-resources:
-  repositories:
-    - repository: templates
-      type: github
-      name: ms-iot/rosonwindows_ci
-      endpoint: ms-iot
-
 pr:
   branches:
     include:
@@ -17,7 +10,7 @@ schedules:
         - master
 
 jobs:
-- template: build.yml@templates  # Template reference
+- template: build.yml@self  # Template reference
   parameters:
     rosdistro: melodic
     metapackage: desktop

--- a/tests/azure-pipelines.yml
+++ b/tests/azure-pipelines.yml
@@ -3,6 +3,7 @@ resources:
     - repository: templates
       type: github
       name: seanyen/rosonwindows_ci
+      ref: 'refs/heads/seanyen/linux'
       endpoint: ms-iot
 
 pr:

--- a/tests/azure-pipelines.yml
+++ b/tests/azure-pipelines.yml
@@ -2,7 +2,7 @@ resources:
   repositories:
     - repository: templates
       type: github
-      name: ms-iot/rosonwindows_ci
+      name: seanyen/rosonwindows_ci
       endpoint: ms-iot
 
 pr:

--- a/tests/azure-pipelines.yml
+++ b/tests/azure-pipelines.yml
@@ -10,7 +10,7 @@ schedules:
         - master
 
 jobs:
-- template: build.yml@self  # Template reference
+- template: /build.yml@self  # Template reference
   parameters:
     rosdistro: melodic
     metapackage: desktop

--- a/tests/azure-pipelines.yml
+++ b/tests/azure-pipelines.yml
@@ -10,7 +10,7 @@ schedules:
         - master
 
 jobs:
-- template: /build.yml@self  # Template reference
+- template: ../build.yml@self  # Template reference
   parameters:
     rosdistro: melodic
     metapackage: desktop

--- a/tests/azure-pipelines.yml
+++ b/tests/azure-pipelines.yml
@@ -12,6 +12,12 @@ pr:
     include:
       - master
 
+schedules:
+  - cron: "0 0 * * *" # Daily midnight build
+    branches:
+      include:
+        - master
+
 jobs:
 - template: build.yml@templates  # Template reference
   parameters:

--- a/tests/azure-pipelines.yml
+++ b/tests/azure-pipelines.yml
@@ -4,7 +4,7 @@ resources:
       type: github
       name: seanyen/rosonwindows_ci
       #ref: 'refs/heads/seanyen/linux'
-      ref: 'v0.1.0'
+      ref: 'refs/tags/v0.1.0'
       endpoint: ms-iot
 
 pr:


### PR DESCRIPTION
Functionality added:
* Adding the initial Linux support which is using [OSRF docker images](https://hub.docker.com/r/osrf/ros/). And one can use `platforms` to decide what OS to build or both.
* Deprecating `ros_metapackage` and break into `rosdistro` and `metapackage` which helps synthesize the ROS package names by different convention.

Testing updated:
* Adding the nightly build trigger for the test pipelines to monitor external resource health.
* Correcting the way referencing to the template by using `self`. Otherwise, it will be using the old version on `ms-iot` before merged.