### PR TITLE
[Windows] Adding `custom_version` parameter to specify what metapackage version to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Under `template`, there are some parameters to customize your CI build:
 
 * `rosdistro` and `metapackage`: You can use `rosdistro` for what ROS distro and `metapackage` for what the composition to check out for your CI build. In this example, it specifies to use `melodic` ROS distro and check out the ROS packages up to `desktop`.
 
-* `custom_version`: You can use this to specify what's the version of the metapackage to checkout. This is currently supported only for Windows builds.
+* `custom_version`: You can use this to specify what's the metapackage version to checkout. This is currently supported only for Windows builds.
 
 * `custom_test_target`: For projects which do not have  `run_tests` as default test target, it can be set to a customized test target.
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ jobs:
   parameters:
     rosdistro: melodic
     metapackage: desktop
-    custom_version: '20200501.1.0' # Optional; default is blank.
-    custom_test_target: 'run_tests'
+    custom_version: '20200501.1.0'  # Optional; default is `latest`.
+    custom_test_target: 'run_tests'  # Optional; default is `run_tests`.
     platforms:
       - linux
       - windows
@@ -50,6 +50,8 @@ Replace `endpoint` to your Github account (or your GitHub service connection nam
 Under `template`, there are some parameters to customize your CI build:
 
 * `rosdistro` and `metapackage`: You can use `rosdistro` for what ROS distro and `metapackage` for what the composition to check out for your CI build. In this example, it specifies to use `melodic` ROS distro and check out the ROS packages up to `desktop`.
+
+* `custom_version`: You can use this to specify what's the version of the metapackage to checkout. This is currently supported only for Windows builds.
 
 * `custom_test_target`: For projects which do not have  `run_tests` as default test target, it can be set to a customized test target.
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ jobs:
   parameters:
     rosdistro: melodic
     metapackage: desktop
+    custom_version: '20200501.1.0' # Optional; default is blank.
     custom_test_target: 'run_tests'
     platforms:
       - linux

--- a/build.yml
+++ b/build.yml
@@ -44,7 +44,7 @@ jobs:
       inputs:
         targetFolder: '$(Build.StagingDirectory)\src\_'
 
-    - ${{ if containsValue(parameters.custom_version, 'latest') }}:
+    - ${{ if eq(parameters.custom_version, 'latest') }}:
       - script: |
           choco sources add -n=roswin -s https://roswin.azurewebsites.net/api/v2/ --priority 1
           choco upgrade ros-%CI_ROSDISTRO%-%CI_METAPACKAGE% -y
@@ -52,7 +52,7 @@ jobs:
         displayName: Install prerequisites
         workingDirectory: $(Build.StagingDirectory)
 
-    - ${{ if not(containsValue(parameters.custom_version, 'latest')) }}:
+    - ${{ if not(eq(parameters.custom_version, 'latest')) }}:
       - script: |
           choco sources add -n=roswin -s https://roswin.azurewebsites.net/api/v2/ --priority 1
           choco upgrade ros-%CI_ROSDISTRO%-%CI_METAPACKAGE% --version=%CUSTOM_VERSION% -y

--- a/build.yml
+++ b/build.yml
@@ -8,6 +8,9 @@ parameters:
 - name: metapackage
   type: string
   default: 'desktop'
+- name: custom_version
+  type: string
+  default: 'latest'
 - name: custom_test_target
   type: string
   default: 'run_tests'
@@ -41,12 +44,23 @@ jobs:
       inputs:
         targetFolder: '$(Build.StagingDirectory)\src\_'
 
-    - script: |
-        choco sources add -n=roswin -s https://roswin.azurewebsites.net/api/v2/ --priority 1
-        choco upgrade ros-%CI_ROSDISTRO%-%CI_METAPACKAGE% -y
-        call "C:\opt\ros\%CI_ROSDISTRO%\x64\env.bat" rosdep install --from-paths src --ignore-src -r -y
-      displayName: Install prerequisites
-      workingDirectory: $(Build.StagingDirectory)
+    - ${{ if containsValue(parameters.custom_version, 'latest') }}:
+      - script: |
+          choco sources add -n=roswin -s https://roswin.azurewebsites.net/api/v2/ --priority 1
+          choco upgrade ros-%CI_ROSDISTRO%-%CI_METAPACKAGE% -y
+          call "C:\opt\ros\%CI_ROSDISTRO%\x64\env.bat" rosdep install --from-paths src --ignore-src -r -y
+        displayName: Install prerequisites
+        workingDirectory: $(Build.StagingDirectory)
+
+    - ${{ if not(containsValue(parameters.custom_version, 'latest')) }}:
+      - script: |
+          choco sources add -n=roswin -s https://roswin.azurewebsites.net/api/v2/ --priority 1
+          choco upgrade ros-%CI_ROSDISTRO%-%CI_METAPACKAGE% --version=%CUSTOM_VERSION% -y
+          call "C:\opt\ros\%CI_ROSDISTRO%\x64\env.bat" rosdep install --from-paths src --ignore-src -r -y
+        displayName: Install prerequisites
+        workingDirectory: $(Build.StagingDirectory)
+        env:
+          CUSTOM_VERSION: ${{ parameters.custom_version }}
 
     - ${{ parameters.pre_build }}
 

--- a/tests/azure-pipelines.yml
+++ b/tests/azure-pipelines.yml
@@ -20,5 +20,6 @@ jobs:
   parameters:
     rosdistro: melodic
     metapackage: ros_core
+    custom_version: '20200501.1.0'
     platforms:
       - windows

--- a/tests/azure-pipelines.yml
+++ b/tests/azure-pipelines.yml
@@ -20,6 +20,5 @@ jobs:
   parameters:
     rosdistro: melodic
     metapackage: ros_core
-    custom_version: '20200501.1.0'
     platforms:
       - windows


### PR DESCRIPTION
Adding `custom_version` for users to decide what metapackage (Chocolatey package) version to download for CI.